### PR TITLE
feat: add YouTubeEmbed component and integrate it into HomeView

### DIFF
--- a/src/components/common/YouTubeEmbed.vue
+++ b/src/components/common/YouTubeEmbed.vue
@@ -1,0 +1,106 @@
+<template>
+    <div class="w-full aspect-video overflow-hidden rounded-2xl bg-black/5 shadow-lg">
+        <button
+            v-if="!isLoaded"
+            type="button"
+            class="group relative h-full w-full"
+            @click="handleLoad"
+            aria-label="Play YouTube video"
+        >
+            <img
+                :src="thumbnailSrc"
+                :alt="thumbnailAlt"
+                class="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+                loading="lazy"
+                @error="handleThumbnailError"
+            />
+            <div
+                class="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/55 via-black/25 to-transparent"
+                aria-hidden="true"
+            ></div>
+            <span
+                class="pointer-events-none absolute left-1/2 top-1/2 flex h-16 w-16 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full bg-white/90 text-black shadow-md"
+                aria-hidden="true"
+            >
+                <svg
+                    viewBox="0 0 24 24"
+                    class="h-8 w-8"
+                    fill="currentColor"
+                >
+                    <path d="M8 5v14l11-7z" />
+                </svg>
+            </span>
+        </button>
+        <iframe
+            v-else
+            class="h-full w-full transition-opacity duration-500"
+            :class="iframeLoaded ? 'opacity-100' : 'opacity-0'"
+            :src="embedSrc"
+            title="YouTube video player"
+            frameborder="0"
+            loading="lazy"
+            allow="autoplay; encrypted-media; picture-in-picture"
+            allowfullscreen
+            @load="handleIframeLoad"
+        ></iframe>
+    </div>
+</template>
+
+<script setup>
+import { computed, ref, watch } from 'vue';
+
+const props = defineProps({
+    videoId: {
+        type: String,
+        required: true,
+    },
+});
+
+const isLoaded = ref(false);
+const iframeLoaded = ref(false);
+const useFallback = ref(false);
+
+const maxResSrc = computed(
+    () => `https://img.youtube.com/vi/${props.videoId}/maxresdefault.jpg`
+);
+const fallbackSrc = computed(
+    () => `https://img.youtube.com/vi/${props.videoId}/hqdefault.jpg`
+);
+
+const thumbnailSrc = computed(() =>
+    useFallback.value ? fallbackSrc.value : maxResSrc.value
+);
+
+const thumbnailAlt = computed(() => 'YouTube video thumbnail');
+
+const embedSrc = computed(() => {
+    const params = new URLSearchParams({
+        autoplay: isLoaded.value ? '1' : '0',
+        rel: '0',
+        modestbranding: '1',
+    });
+
+    return `https://www.youtube-nocookie.com/embed/${props.videoId}?${params.toString()}`;
+});
+
+const handleThumbnailError = () => {
+    useFallback.value = true;
+};
+
+const handleLoad = () => {
+    isLoaded.value = true;
+};
+
+const handleIframeLoad = () => {
+    iframeLoaded.value = true;
+};
+
+watch(
+    () => props.videoId,
+    () => {
+        useFallback.value = false;
+        isLoaded.value = false;
+        iframeLoaded.value = false;
+    }
+);
+</script>

--- a/src/components/ui/YouTubeEmbed.vue
+++ b/src/components/ui/YouTubeEmbed.vue
@@ -1,0 +1,77 @@
+<template>
+    <div class="w-full aspect-video overflow-hidden rounded-xl bg-black/5 p-5">
+        <button
+            v-if="!isLoaded"
+            type="button"
+            class="relative h-full w-full"
+            @click="handleLoad"
+            aria-label="Play YouTube video"
+        >
+            <img
+                :src="thumbnailSrc"
+                :alt="thumbnailAlt"
+                class="h-full w-full object-cover"
+                loading="lazy"
+            />
+            <span
+                class="absolute left-1/2 top-1/2 flex h-16 w-16 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full bg-black/70 text-white"
+                aria-hidden="true"
+            >
+                <svg
+                    viewBox="0 0 24 24"
+                    class="h-8 w-8"
+                    fill="currentColor"
+                >
+                    <path d="M8 5v14l11-7z" />
+                </svg>
+            </span>
+        </button>
+        <iframe
+            v-else
+            class="h-full w-full"
+            :src="embedSrc"
+            title="YouTube video player"
+            frameborder="0"
+            loading="lazy"
+            allow="autoplay; encrypted-media; picture-in-picture"
+            allowfullscreen
+        ></iframe>
+    </div>
+</template>
+
+<script setup>
+import { computed, ref } from 'vue';
+
+const props = defineProps({
+    videoId: {
+        type: String,
+        required: true,
+    },
+    autoplay: {
+        type: Boolean,
+        default: false,
+    },
+});
+
+const isLoaded = ref(false);
+
+const thumbnailSrc = computed(
+    () => `https://i.ytimg.com/vi/${props.videoId}/maxresdefault.jpg`
+);
+
+const thumbnailAlt = computed(() => `YouTube video thumbnail`);
+
+const embedSrc = computed(() => {
+    const autoplayValue = isLoaded.value && props.autoplay ? 1 : 0;
+    const params = new URLSearchParams({
+        autoplay: autoplayValue.toString(),
+        rel: '0',
+    });
+
+    return `https://www.youtube-nocookie.com/embed/${props.videoId}?${params.toString()}`;
+});
+
+const handleLoad = () => {
+    isLoaded.value = true;
+};
+</script>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -1,6 +1,7 @@
 <template>
     <div class="home-view">
         <HeroSection />
+        <YouTubeEmbed video-id="w1u8W7lK0RY" />
         <WelcomeSection />
         <AboutUs />
         <MascottPreview />
@@ -14,6 +15,7 @@ import PhotoCarousel from '@/components/features/home/PhotoCarousel.vue';
 import WelcomeSection from '../components/features/home/WelcomeSection.vue';
 import AboutUs from '../components/features/home/AboutUs.vue';
 import MascottPreview from '../components/features/home/MascottPreview.vue';
+import YouTubeEmbed from '@/components/common/YouTubeEmbed.vue';
 </script>
 
 <style scoped>


### PR DESCRIPTION
This pull request introduces a new reusable YouTube video embed component and integrates it into the home page. The main focus is on providing a user-friendly, lazy-loaded video preview with a play button overlay, improving both performance and user experience. Two versions of the component are added for different UI contexts.

YouTube embed component additions:

* Added `YouTubeEmbed.vue` in `src/components/common/` with lazy loading, thumbnail fallback, and a stylized preview/play overlay. This component handles thumbnail errors, transitions smoothly to the embedded video, and resets state on video changes.
* Added a simplified variant of `YouTubeEmbed.vue` in `src/components/ui/` for alternate UI needs, supporting basic lazy loading and optional autoplay.

Home page integration:

* Imported and used the new `YouTubeEmbed` component in `HomeView.vue`, embedding a YouTube video after the hero section. [[1]](diffhunk://#diff-b4e148caffc7f5789860e9b26c3e16ad29aceb39cfda5ffb9e2a746a5cec48ccR4) [[2]](diffhunk://#diff-b4e148caffc7f5789860e9b26c3e16ad29aceb39cfda5ffb9e2a746a5cec48ccR18)